### PR TITLE
Add support for pyrogram 0.8.0

### DIFF
--- a/tgintegration/botintegrationclient.py
+++ b/tgintegration/botintegrationclient.py
@@ -59,7 +59,7 @@ class BotIntegrationClient(InteractionClient):
         Raises:
             :class:`Error <pyrogram.Error>`
         """
-        res = super().start(debug=debug)
+        res = super().start()
 
         self.peer = self.resolve_peer(self.bot_under_test)
         self.peer_id = self.peer.user_id

--- a/tgintegration/interactionclient.py
+++ b/tgintegration/interactionclient.py
@@ -218,7 +218,7 @@ class InteractionClient(Client):
         request = GetBotCallbackAnswer(
             peer=self.resolve_peer(chat_id),
             msg_id=mid,
-            data=bytes(callback_data, 'utf-8')
+            data=callback_data
         )
 
         if retries > 0:

--- a/tgintegration/response.py
+++ b/tgintegration/response.py
@@ -2,7 +2,7 @@ import time
 from datetime import datetime
 
 from pyrogram import InlineKeyboardMarkup
-from pyrogram.client.types.reply_markup.reply_keyboard_markup import ReplyKeyboardMarkup
+from pyrogram.client.types.bots.reply_keyboard_markup import ReplyKeyboardMarkup
 
 from tgintegration.containers import InlineKeyboard, ReplyKeyboard
 


### PR DESCRIPTION
Closes #1 

There were only minor changes to make the module able to be loaded and run. I have not extensively tested any other features but at least this PR will make the module usable again with pyrogram 0.8.0 and tgcrypto 1.1.1