### PR TITLE
Fixing 'bot_info' attribute from GetFullUser

### DIFF
--- a/tgintegration/botcontroller.py
+++ b/tgintegration/botcontroller.py
@@ -132,7 +132,7 @@ class BotController:
                     await self.client.send(
                         GetFullUser(id=await self.client.resolve_peer(self.peer_id))
                     )
-                ).bot_info,
+                ).full_user.bot_info,
             ).commands
         )
 


### PR DESCRIPTION
Hey there!
Great library, thank you for the tremendous effort so far, huge props! 🎉 

I tried to follow the example and after creating a user client (just like in Pyrogram), I tried to initialize a BotController and `send_command` but I kept hitting this same error:

`AttributeError: 'UserFull' object has no attribute 'bot_info'`

After a quick debug, I realised the wanted `bot_info` was further down, inside `full_user`.  This should work now! 😄 